### PR TITLE
Add docker binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN tar zxvf consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tar.gz && \
     rm -rf /consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64 && \
     mkdir -p /consul-template /consul-template/config.d /consul-template/templates
 
+ADD https://get.docker.com/builds/Linux/x86_64/docker-latest /bin/docker
+RUN chmod +x /bin/docker
+
 CMD ["/bin/consul-template"]


### PR DESCRIPTION
Somehow bind-mounting CoreOS docker binary doesn't work as expected.

On a CoreOS box:

```
coreos> docker run -it --rm -v /usr/bin/docker:/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock gliderlabs/alpine:3.1 /bin/sh

container> which docker
container> /usr/bin/docker

container> docker --version
container> /bin/sh: docker: not found

container> /usr/bin/docker --version
container> /bin/sh: /usr/bin/docker: not found

# PATH seems correct
container> echo $PATH
container> /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

Presumably fails because CoreOS uses docker with modification? I don't know. 

```
coreos> docker -v
coreos> Docker version 1.7.1, build 786b29d-dirty
```

Similar errors happen when ubuntu is the base image.

Having docker inside solves the issue. I believe that won't be a problem anyway.
